### PR TITLE
Switch Apple back to handler extensions

### DIFF
--- a/Maui.ContentButton/Apple/ContentButtonHandler.ios.maccatalyst.cs
+++ b/Maui.ContentButton/Apple/ContentButtonHandler.ios.maccatalyst.cs
@@ -34,9 +34,7 @@ public partial class ContentButtonHandler : ViewHandler<IContentButton, MButton>
 	{
 		if (handler.PlatformView.Configuration is not null)
 		{
-			var con = handler.PlatformView.Configuration;
-			con.Background.BackgroundColor = button.Background?.ToColor()?.ToPlatform();
-			handler.PlatformView.Configuration = con;
+			handler.PlatformView.UpdateBackground(button.Background, button);
 		}
 	}
 
@@ -44,9 +42,7 @@ public partial class ContentButtonHandler : ViewHandler<IContentButton, MButton>
 	{
 		if (handler.PlatformView.Configuration is not null)
 		{
-			var con = handler.PlatformView.Configuration;
-			con.Background.StrokeColor = buttonStroke.StrokeColor?.ToPlatform();
-			handler.PlatformView.Configuration = con;
+			handler.PlatformView.UpdateStrokeColor(buttonStroke);
 		}
 	}
 
@@ -54,9 +50,7 @@ public partial class ContentButtonHandler : ViewHandler<IContentButton, MButton>
 	{
 		if (handler.PlatformView.Configuration is not null)
 		{
-			var con = handler.PlatformView.Configuration;
-			con.Background.StrokeWidth = (float)buttonStroke.StrokeThickness;
-			handler.PlatformView.Configuration = con;
+			handler.PlatformView.UpdateStrokeThickness(buttonStroke);
 		}
 	}
 
@@ -64,9 +58,7 @@ public partial class ContentButtonHandler : ViewHandler<IContentButton, MButton>
 	{
 		if (handler.PlatformView.Configuration is not null)
 		{
-			var con = handler.PlatformView.Configuration;
-			con.Background.CornerRadius = buttonStroke.CornerRadius;
-			handler.PlatformView.Configuration = con;
+			handler.PlatformView.UpdateCornerRadius(buttonStroke);
 		}
 	}
 

--- a/Sample/MainPage.xaml
+++ b/Sample/MainPage.xaml
@@ -29,6 +29,14 @@
                 x:Name="CounterBtn"
                 Clicked="OnCounterClicked"
                 HorizontalOptions="Fill">
+                <mcb:ContentButton.Background>
+                    <LinearGradientBrush
+                        StartPoint="0,0"
+                        EndPoint="1,1">
+                        <GradientStop Color="{DynamicResource Primary}" Offset="0.0" />
+                        <GradientStop Color="{DynamicResource Secondary}" Offset="1.0" />
+                    </LinearGradientBrush>
+                </mcb:ContentButton.Background>
                 <Grid ColumnDefinitions="Auto,*,Auto,Auto" RowDefinitions="*,*">
                     <Image
                         Source="dotnet_bot.png"


### PR DESCRIPTION
This goes back to the older existing extension methods instead of using UIButtonConfiguration for now so that we regain the ability to use complex backgrounds such as gradients.